### PR TITLE
update scroll/resize info for scroll/resize start/end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscribe-ui-event",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A single, throttle built-in solution to subscribe to browser UI Events.",
   "main": "index.js",
   "scripts": {

--- a/src/AugmentedEvent.js
+++ b/src/AugmentedEvent.js
@@ -4,6 +4,15 @@
  */
 'use strict';
 
+var scroll = {
+    delta: 0,
+    top: 0
+};
+var resize = {
+    width: 0,
+    height: 0
+};
+
 /**
  * ArgmentedEvent will hold some global information, such like window scroll postion,
  * so that those information is only calculated once.
@@ -12,14 +21,8 @@
 function ArgmentedEvent(option) {
     option = option || {};
     this.type = option.type || '';
-    this.scroll = {
-        delta: 0,
-        top: 0
-    };
-    this.resize = {
-        width: 0,
-        height: 0
-    };
+    this.scroll = scroll;
+    this.resize = resize;
 }
 
 module.exports = ArgmentedEvent;

--- a/src/eventHandlers/index.js
+++ b/src/eventHandlers/index.js
@@ -53,11 +53,11 @@ function copyEventObj(o) {
  */
 function updateAdditionalInfo(ae, eventType) {
     var top;
-    if (eventType === 'scroll' && enableScrollInfo) {
+    if (enableScrollInfo && eventType === 'scroll') {
         top = docEl.scrollTop + docBody.scrollTop;
         ae.scroll.delta = top - ae.scroll.top;
         ae.scroll.top = top;
-    } else if (eventType === 'resize' && enableResizeInfo) {
+    } else if (enableResizeInfo && eventType === 'resize') {
         ae.resize.width = win.innerWidth || docEl.clientWidth;
         ae.resize.height = win.innerHeight || docEl.clientHeight;
     }


### PR DESCRIPTION
@roderickhsiao, fix some issues

1. Scroll/resize information is global, should be shared by all event handlers. So make them as global.
2. `updateAdditionalInfo` not only for scroll/resize but also scrollStart/scrollEnd/resizeStart/resizeEnd.

Ya