### PR TITLE
fix enableScroll not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subscribe-ui-event",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A single, throttle built-in solution to subscribe to browser UI Events.",
   "main": "index.js",
   "scripts": {

--- a/src/eventHandlers/index.js
+++ b/src/eventHandlers/index.js
@@ -99,6 +99,10 @@ function listen(target, eventType, handler) {
  */
 function generateEdgeEventHandler(target, eventType, eventStart) {
     return function(eeType, options) {
+        // One subscription needs scroll/resize info, all will get those information
+        enableScrollInfo = enableScrollInfo || options.enableScrollInfo;
+        enableResizeInfo = enableResizeInfo || options.enableResizeInfo;
+
         if (ee.listeners(eeType, true)) {
             return;
         }
@@ -153,6 +157,10 @@ function generateEdgeEventHandler(target, eventType, eventStart) {
  */
 function generateContinuousEventHandler(target, eventType, noThrottle) {
     return function(eeType, options) {
+        // One subscription needs scroll/resize info, all will get those information
+        enableScrollInfo = enableScrollInfo || options.enableScrollInfo;
+        enableResizeInfo = enableResizeInfo || options.enableResizeInfo;
+
         if (ee.listeners(eeType, true)) {
             return;
         }
@@ -160,8 +168,6 @@ function generateContinuousEventHandler(target, eventType, noThrottle) {
         var throttleRate = options.throttleRate;
         var throttle = options.throttleFunc;
         var ae = new AugmentedEvent({type: eventType});
-        enableScrollInfo = enableScrollInfo || options.enableScrollInfo;
-        enableResizeInfo = enableResizeInfo || options.enableResizeInfo;
 
         function eventHandler(e) {
             updateAdditionalInfo(ae, eventType);

--- a/tests/unit/subscribe.js
+++ b/tests/unit/subscribe.js
@@ -208,7 +208,7 @@ describe('subscribe', function () {
             ee.emit('scroll', {foo: 'foo'});
         });
 
-        it.only('resize should be triggered by window resize with resize information', function (done) {
+        it('resize should be triggered by window resize with resize information', function (done) {
             // the first one subscription should get resize info as well, because the second one requests
             var subscription1 = subscribe('resize', function (e, syntheticEvent) {
                 expect(e.foo).equal('foo');
@@ -225,7 +225,7 @@ describe('subscribe', function () {
                 done();
             }, {enableResizeInfo: true});
 
-            // simulate window scroll event
+            // simulate window resize event
             ee.emit('resize', {foo: 'foo'});
         });
 

--- a/tests/unit/subscribe.js
+++ b/tests/unit/subscribe.js
@@ -186,12 +186,21 @@ describe('subscribe', function () {
             ee.emit('resize', {foo: 'foo'});
         });
 
-        it('scroll should be triggered by window scroll with scroll information', function (done) {
-            var subscription = subscribe('scroll', function (e, syntheticEvent) {
+        it.only('scroll should be triggered by window scroll with scroll information', function (done) {
+            // the first one subscription should get scroll info as well, because information is global
+            var subscription1 = subscribe('scroll', function (e, syntheticEvent) {
                 expect(e.foo).equal('foo');
                 expect(syntheticEvent.type).equal('scroll');
                 expect(syntheticEvent.scroll.top).equal(10);
-                subscription.unsubscribe();
+                subscription1.unsubscribe();
+            }, {enableScrollInfo: false});
+
+            // the second one request scroll info, which should dominate.
+            var subscription2 = subscribe('scroll', function (e, syntheticEvent) {
+                expect(e.foo).equal('foo');
+                expect(syntheticEvent.type).equal('scroll');
+                expect(syntheticEvent.scroll.top).equal(10);
+                subscription2.unsubscribe();
                 done();
             }, {enableScrollInfo: true});
 

--- a/tests/unit/subscribe.js
+++ b/tests/unit/subscribe.js
@@ -186,8 +186,8 @@ describe('subscribe', function () {
             ee.emit('resize', {foo: 'foo'});
         });
 
-        it.only('scroll should be triggered by window scroll with scroll information', function (done) {
-            // the first one subscription should get scroll info as well, because information is global
+        it('scroll should be triggered by window scroll with scroll information', function (done) {
+            // the first one subscription should get scroll info as well, because the second one requests
             var subscription1 = subscribe('scroll', function (e, syntheticEvent) {
                 expect(e.foo).equal('foo');
                 expect(syntheticEvent.type).equal('scroll');
@@ -208,12 +208,20 @@ describe('subscribe', function () {
             ee.emit('scroll', {foo: 'foo'});
         });
 
-        it('resize should be triggered by window resize with resize information', function (done) {
-            var subscription = subscribe('resize', function (e, syntheticEvent) {
+        it.only('resize should be triggered by window resize with resize information', function (done) {
+            // the first one subscription should get resize info as well, because the second one requests
+            var subscription1 = subscribe('resize', function (e, syntheticEvent) {
                 expect(e.foo).equal('foo');
                 expect(syntheticEvent.type).equal('resize');
                 expect(syntheticEvent.resize.width).equal(10);
-                subscription.unsubscribe();
+                subscription1.unsubscribe();
+            }, {enableResizeInfo: false});
+
+            var subscription2 = subscribe('resize', function (e, syntheticEvent) {
+                expect(e.foo).equal('foo');
+                expect(syntheticEvent.type).equal('resize');
+                expect(syntheticEvent.resize.width).equal(10);
+                subscription2.unsubscribe();
                 done();
             }, {enableResizeInfo: true});
 


### PR DESCRIPTION
@roderickhsiao @kaesonho, 
For `enableScrollInfo/enableResizeInfo`, all subscriptions will get those information if one request. But the previous code will return for the second `subscribe` call and ignore the settings.