### PR TITLE
Switch to use babel

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
         'grunt-contrib-connect',
         'grunt-contrib-jshint',
         'grunt-contrib-watch',
-        'grunt-react',
+        'grunt-babel',
         'grunt-shell',
         'grunt-webpack'
     ].forEach(function (packageName) {
@@ -91,8 +91,11 @@ module.exports = function (grunt) {
         },
         // react
         // compiles jsx to js
-        react: {
+        babel: {
             dist: {
+                options: {
+                    sourceMap: false
+                },
                 files: [
                     {
                         expand: true,
@@ -105,6 +108,9 @@ module.exports = function (grunt) {
                 ]
             },
             functional: {
+                options: {
+                    sourceMap: false
+                },
                 files: [
                     {
                         expand: true,
@@ -115,6 +121,9 @@ module.exports = function (grunt) {
                 ]
             },
             unit: {
+                options: {
+                    sourceMap: false
+                },
                 files: [
                     {
                         expand: true,
@@ -154,7 +163,7 @@ module.exports = function (grunt) {
                 module: {
                     loaders: [
                         { test: /\.css$/, loader: 'style!css' },
-                        { test: /\.jsx$/, loader: 'jsx-loader' },
+                        { test: /\.jsx$/, loader: 'babel-loader' },
                         { test: /\.json$/, loader: 'json-loader'}
                     ]
                 }
@@ -192,7 +201,7 @@ module.exports = function (grunt) {
         'saucelabs-mocha': {
             all: {
                 options: {
-                    testname: 'react-i13n func test',
+                    testname: 'subscribe ui event func test',
                     urls: [
                         'http://127.0.0.1:9999/tests/functional/page.html'
                     ],
@@ -294,8 +303,8 @@ module.exports = function (grunt) {
     grunt.registerTask('cover', [
         'clean:tmp',
         'clean:dist',
-        'react:unit',
-        'react:dist',
+        'babel:unit',
+        'babel:dist',
         'shell:istanbul',
         'clean:tmp'
     ]);
@@ -303,16 +312,16 @@ module.exports = function (grunt) {
     grunt.registerTask('unit', [
         'clean:tmp',
         'clean:dist',
-        'react:unit',
-        'react:dist',
+        'babel:unit',
+        'babel:dist',
         'shell:mocha'
     ]);
 
     // dist
     // 1. clean dist/
     // 2. compile jsx to js in dist/
-    grunt.registerTask('dist', ['clean:dist', 'react:dist']);
-    grunt.registerTask('test', ['clean:dist', 'react:dist', 'clean:tmp', 'react:unit']);
+    grunt.registerTask('dist', ['clean:dist', 'babel:dist']);
+    grunt.registerTask('test', ['clean:dist', 'babel:dist', 'clean:tmp', 'babel:unit']);
 
     // default
     grunt.registerTask('default', ['dist']);

--- a/package.json
+++ b/package.json
@@ -29,16 +29,17 @@
   },
   "devDependencies": {
     "async": "^1.4.0",
+    "babel-loader": "^5.1.3",
     "coveralls": "^2.11.1",
     "es5-shim": "^4.0.0",
     "expect.js": "^0.3.1",
     "grunt-atomizer": "^3.0.0",
+    "grunt-babel": "^5.0.0",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-connect": "^0.11.0",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-react": "^0.12.2",
     "grunt-saucelabs": "^8.3.2",
     "grunt-shell": "^1.1.2",
     "grunt-webpack": "^1.0.8",
@@ -46,13 +47,12 @@
     "istanbul": "^0.3.0",
     "jsdom": "^6.0.0",
     "jshint": "^2.5.1",
-    "jsx-loader": "^0.13.2",
     "minimist": "^1.0.0",
     "mocha": "^2.0",
     "mockery": "^1.4.0",
     "pre-commit": "^1.0.0",
     "react": "^0.13.x",
-    "xunit-file": "^0.0.7"
+    "xunit-file": "~0.0.7"
   },
   "precommit": [
     "lint",

--- a/tests/unit/subscribe.js
+++ b/tests/unit/subscribe.js
@@ -291,7 +291,7 @@ describe('subscribe', function () {
             // simulate window scroll event
             ee.emit('visibilitychange', {foo: 'foo'});
         });
-        
+
         it('should not have fatal error if multiple unsubscibe happens', function (done) {
             var subscription = subscribe('scroll', function (e, syntheticEvent) {
                 expect(e.foo).equal('foo');


### PR DESCRIPTION
@hankhsiao 

This PR switch `grunt-react` to `grunt-babel`, `jsx-loader` to `babel-loader`.