### PR TITLE
update eventemitter3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "author": "Hank Hsiao <hankxiao@yahoo-inc.com>",
   "dependencies": {
-    "eventemitter3": "^1.1.0",
+    "eventemitter3": "^2.0.0",
     "lodash": "^4.0.0",
     "raf": "^3.0.0"
   },


### PR DESCRIPTION
better performance, 
We are [not inheriting it](https://github.com/yahoo/subscribe-ui-event/blob/master/src/globalVars.js#L11), so shouldn't be impacted by the breaking change

https://github.com/primus/eventemitter3/releases/tag/2.0.0


@src-code  @roderickhsiao @hankhsiao 

