### PR TITLE
Update eventemitter3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "author": "Hank Hsiao <hankxiao@yahoo-inc.com>",
   "dependencies": {
-    "eventemitter3": "^2.0.0",
+    "eventemitter3": "^3.0.0",
     "lodash": "^4.0.0",
     "raf": "^3.0.0"
   },


### PR DESCRIPTION
We are not using the breaking changes
https://github.com/primus/eventemitter3/releases/tag/3.0.0

so be able to safely upgrade.