### PR TITLE
Set default option passive: false

### DIFF
--- a/src/lib/listen.js
+++ b/src/lib/listen.js
@@ -8,7 +8,7 @@ var globalVars = require('../globalVars');
 
 var defaultEventOption = {
   capture: false,
-  passive: true
+  passive: false
 };
 
 /**


### PR DESCRIPTION
Some other library is using the `listen` library directly

https://github.com/yahoo/react-i13n/blob/master/src/libs/ComponentSpecs.js#L146

which breaks as default option now is `passive: on`, the `preventDefault` won't work. 😢 

Instead of having a whitelist to filter out event, I would rather to just user to pass passive event by themselves. 

@redonkulus 