### PR TITLE
index.es.js should be in ES5 + ESModules

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -7,7 +7,7 @@ import listenLib from './dist-es/lib/listen';
 import subscribeLib from './dist-es/subscribe';
 import unsubscribeLib from './dist-es/unsubscribe';
 
-const IS_CLIENT = typeof window !== 'undefined';
+var IS_CLIENT = typeof window !== 'undefined';
 
 function warn() {
   if (process.env.NODE_ENV !== 'production') {

--- a/index.es.js
+++ b/index.es.js
@@ -15,6 +15,6 @@ function warn() {
   }
 }
 
-export const listen = IS_CLIENT ? listenLib : warn;
-export const subscribe = IS_CLIENT ? subscribeLib : warn;
-export const unsubscribe = IS_CLIENT ? unsubscribeLib : warn;
+export var listen = IS_CLIENT ? listenLib : warn;
+export var subscribe = IS_CLIENT ? subscribeLib : warn;
+export var unsubscribe = IS_CLIENT ? unsubscribeLib : warn;


### PR DESCRIPTION
This is because webpack's default resolution of main fields is:`mainFields: ['browser', 'module', 'main']`, which means` index.es.js` is selected by webpack even if it targets older IEs.

https://webpack.js.org/configuration/resolve/

I've set its value to `mainFields: ["browser", "main", "module"]` for now in my project, but  I think the "module" entry point should be written in ES5 + ESModules, not ES2015 + ESModules.